### PR TITLE
Use two step PR approval process for IP Compliance team members

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
       # identical across the unit-tests, e2e-tests, and consistency-checks
       # jobs, or else weird things could happen.
       - name: Cache Go modules
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: "~/go/pkg"
           key: go-mod-${{ hashFiles('go.sum') }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -66,7 +66,7 @@ jobs:
       # identical across the unit-tests and consistency-checks
       # jobs, or else weird things could happen.
       - name: Cache Go modules
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: "~/go/pkg"
           key: go-mod-${{ hashFiles('go.sum') }}

--- a/.github/workflows/two-step-pr-approval.yaml
+++ b/.github/workflows/two-step-pr-approval.yaml
@@ -1,0 +1,20 @@
+name: Two-Stage PR Review Process
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  manage-pr-status:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Two stage PR review
+        uses: hashicorp/two-stage-pr-approval@v0.1.0

--- a/.github/workflows/two-step-pr-approval.yaml
+++ b/.github/workflows/two-step-pr-approval.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       
       - name: Two stage PR review
         uses: hashicorp/two-stage-pr-approval@v0.1.0


### PR DESCRIPTION
We have been instating this process to ensure that any PRs raised by IP compliance team members follows a comprehensive internal team review first and then become open for wider review for shared/core libraries that we co-own.
Memo for this change : https://go.hashi.co/memo/eng-001